### PR TITLE
fix: isVueProject path on Windows

### DIFF
--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -34,7 +34,7 @@ export default class Common {
   }
 
   public static isVueProject(): Boolean {
-    const projectUrl = vscode.workspace.workspaceFolders[0].uri.path
+    const projectUrl = vscode.workspace.workspaceFolders[0].uri.fsPath
 
     try {
       const {


### PR DESCRIPTION
Similar to #4 

`uri.path` is invalid path on Windows