### PR TITLE
feat: add a configuration option `sourceLocale`

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,11 @@
           "type": "string",
           "default": "",
           "description": "翻译文件的目录（相对于根目录）"
+        },
+        "vue-i18n.sourceLocale": {
+          "type": "string",
+          "default": "zh-CN",
+          "description": "机器翻译源语言"
         }
       }
     }

--- a/src/transCenter.ts
+++ b/src/transCenter.ts
@@ -59,7 +59,8 @@ export class TransCenter {
             type: EVENT_MAP.allI18n,
             data: {
               filePath: shortFileName,
-              i18n: i18nFiles.getTrans(filePath)
+              i18n: i18nFiles.getTrans(filePath),
+              sourceLocale: Common.getSourceLocale()
             }
           })
           break

--- a/src/utils/I18nFile.ts
+++ b/src/utils/I18nFile.ts
@@ -3,7 +3,7 @@ import * as path from 'path'
 import * as fs from 'fs'
 import { set, get } from 'lodash'
 
-import lngs from './lngs'
+import Common from './common';
 
 export interface II18nItem {
   key: string
@@ -28,23 +28,6 @@ class I18nFile {
     this.watchChange(rootPath)
   }
 
-  private static normalizeLng(lng) {
-    const result = lngs.find((lngItem: string | string[]) => {
-      if (Array.isArray(lngItem) && lngItem[1].includes(lng)) {
-        return true
-      }
-
-      if (
-        typeof lngItem === 'string' &&
-        lng.toUpperCase() === lngItem.toUpperCase()
-      ) {
-        return true
-      }
-    })
-
-    return result ? (Array.isArray(result) ? result[0] : result) : ''
-  }
-
   getLngs() {
     const rootPath = this.rootPath
     const i18nList = fs
@@ -57,12 +40,12 @@ class I18nFile {
           rootPath,
           path: filePath,
           isDirectory,
-          lng: I18nFile.normalizeLng(originLng)
+          lng: Common.normalizeLng(originLng)
         }
       })
       .filter((item: any) => !!item.lng)
       .sort(item => {
-        return item.lng === 'zh-CN' ? -1 : 1
+        return item.lng === Common.getSourceLocale() ? -1 : 1
       })
 
     return i18nList

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode'
 import { join } from 'path'
+import lngs from './lngs'
 
 const configPrefix = 'vue-i18n'
 
@@ -23,6 +24,10 @@ export default class Common {
     Common.setConfig('i18nPaths', i18nPaths.join(','))
   }
 
+  static getSourceLocale() {
+    return Common.normalizeLng(Common.getConfig('sourceLocale')) || 'zh-CN'
+  }
+
   static getConfig(key): any {
     return vscode.workspace.getConfiguration().get(`${configPrefix}.${key}`)
   }
@@ -31,6 +36,23 @@ export default class Common {
     return vscode.workspace
       .getConfiguration()
       .update(`${configPrefix}.${key}`, value, isGlobal)
+  }
+
+  static normalizeLng(lng) {
+    const result = lngs.find((lngItem: string | string[]) => {
+      if (Array.isArray(lngItem) && lngItem[1].includes(lng)) {
+        return true
+      }
+
+      if (
+        typeof lngItem === 'string' &&
+        lng.toUpperCase() === lngItem.toUpperCase()
+      ) {
+        return true
+      }
+    })
+
+    return result ? (Array.isArray(result) ? result[0] : result) : ''
   }
 
   public static isVueProject(): Boolean {

--- a/src/utils/i18nFiles.ts
+++ b/src/utils/i18nFiles.ts
@@ -66,15 +66,17 @@ class I18nFiles {
   }
 
   getTransByApi(transItems: ITransItem[]): Promise<ITransItem[]> {
-    const cnItem = transItems.find(transItem => transItem.lng === 'zh-CN')
+    const sourceLocale =  Common.getSourceLocale()
+    const cnItem = transItems.find(transItem => transItem.lng === sourceLocale)
 
     const tasks = transItems.map(transItem => {
-      if (transItem.lng === 'zh-CN') return transItem
+
+      if (transItem.lng === sourceLocale) return transItem
 
       const plans = [google.translate, baidu.translate, youdao.translate]
       return this.transByApi(
         {
-          from: 'zh-CN',
+          from: sourceLocale,
           to: transItem.lng,
           text: cnItem.data
         },

--- a/src/utils/transAndRefactor.ts
+++ b/src/utils/transAndRefactor.ts
@@ -98,7 +98,7 @@ const transAndRefactor = async ({
   })
 
   // 写入翻译
-  const transZhCN = transData.find(item => item.lng === 'zh-CN')
+  const transZhCN = transData.find(item => item.lng === Common.getSourceLocale())
   transZhCN.data = text
 
   const transByApiData = await i18nFiles.getTransByApi(transData)

--- a/static/transCenter.html
+++ b/static/transCenter.html
@@ -155,7 +155,7 @@
         <h2>
           <span>{{ filePath }}</span>
           <button @click="batchTrans()">
-            {{transTasks.length ? '翻译中' : `批量根据zh-CN翻译` }}
+            {{transTasks.length ? '翻译中' : `批量根据${sourceLocale}翻译` }}
           </button>
         </h2>
         <small>{{ i18nPath }}</small>
@@ -169,13 +169,13 @@
               @click="trans(i18nItem)"
               :disabled="loadingMap[i18nItem.key]"
             >
-              {{loadingMap[i18nItem.key] ? `翻译中..` : `根据zh-CN翻译`}}
+              {{loadingMap[i18nItem.key] ? `翻译中..` : `根据${sourceLocale}翻译`}}
             </button>
           </h4>
 
           <ul>
             <li v-for="transItem in i18nItem.transItems" :key="transItem.lng">
-              <span class="lng" :class="{active: transItem.lng === 'zh-CN'}">{{
+              <span class="lng" :class="{active: transItem.lng === sourceLocale}">{{
                 transItem.lng
               }}</span>
               <input
@@ -209,7 +209,8 @@
             i18n: [],
             loadingMap: {},
             transTasks: [],
-            emitTransTimer: null
+            emitTransTimer: null,
+            sourceLocale: 'zh-CN'
           };
         },
         computed: {
@@ -228,6 +229,7 @@
               case EVENT_MAP.allI18n:
                 this.filePath = data.filePath;
                 this.i18n = data.i18n;
+                this.sourceLocale = data.sourceLocale;
                 break;
 
               case EVENT_MAP.trans:


### PR DESCRIPTION
## 功能
- 添加设置选项`vue-i18n.sourceLocale`(默认`zh-CN`)，可用于指定翻译的源语言 

![image](https://user-images.githubusercontent.com/11247099/57195620-5e9b1280-6f87-11e9-9319-dfb14f006041.png)
![image](https://user-images.githubusercontent.com/11247099/57195634-7e323b00-6f87-11e9-9e01-63307d5b755e.png)

refer to #8 

### 其他
- 将i18nFile.ts中的`normalizeLng`移至`common.ts`

