### PR TITLE
fix: 解析数组下标

### DIFF
--- a/src/utils/I18nFile.ts
+++ b/src/utils/I18nFile.ts
@@ -142,7 +142,7 @@ class I18nFile {
       }
 
       const data = this.files[item.path]
-      const [, ...keyPath] = i18nKey.split('.')
+      const keyPath = i18nKey.replace(/[^.]+\.(.+)/, '$1')
 
       return {
         ...item,


### PR DESCRIPTION
修正了无法解析数组下标的问题。
使用数组下标是为了更好地区分对象与数组。

修正前：
<img width="730" alt="WX20190606-163401@2x" src="https://user-images.githubusercontent.com/16203518/59018871-76610180-8879-11e9-85b4-bfe30b0500f2.png">

修正后：
<img width="711" alt="WX20190606-163454@2x" src="https://user-images.githubusercontent.com/16203518/59018897-87aa0e00-8879-11e9-8fb1-714ebc63d090.png">
