### PR TITLE
feat: 增加公用目录配置 文件未匹配时尝试读取短横线命名文件

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,16 @@
           "default": "",
           "description": "翻译文件的目录（相对于项目根目录）"
         },
+        "vue-i18n.i18nCommonPath": {
+          "type": "string",
+          "default": "",
+          "description": "公用翻译文件的目录（相对于项目根目录）。在未找到翻译项时，插件会尝试到该目录下寻找"
+        },
+        "vue-i18n.filenameToKebabCase": {
+          "type": "boolean",
+          "default": false,
+          "description": "如果找不到翻译文件，是否尝试将文件名转化为短横线命名格式再次查找"
+        },
         "vue-i18n.sourceLocale": {
           "type": "string",
           "default": "zh-CN",


### PR DESCRIPTION
为了解决两个问题
1. 项目中有子项目的i18n合并了crm下的i18n，插件目前是就近查找i18n文件，在子项目的locales文件夹下找不到翻译项，导致无法识别。因此增加了一个公用目录配置，如果找不到，就到该共用目录下查找。
2. 项目中存在i18n键和文件命名不匹配的情况，i18n键用的是驼峰命名，文件名使用短横线命名。这种情况vue-i18n可以识别，但是插件目前无法识别。